### PR TITLE
Introduce OOP base classes for tests

### DIFF
--- a/APIAutomation/ApiTestBase.cs
+++ b/APIAutomation/ApiTestBase.cs
@@ -1,0 +1,21 @@
+using RestSharp;
+using NUnit.Framework;
+
+namespace APIAutomation;
+
+public abstract class ApiTestBase
+{
+    protected RestClient Client { get; private set; } = default!;
+
+    [OneTimeSetUp]
+    public void GlobalSetUp()
+    {
+        Client = new RestClient("https://jsonplaceholder.typicode.com");
+    }
+
+    protected async Task<RestResponse<T>> GetAsync<T>(string resource)
+    {
+        var request = new RestRequest(resource, Method.Get);
+        return await Client.ExecuteGetAsync<T>(request);
+    }
+}

--- a/APIAutomation/UnitTest1.cs
+++ b/APIAutomation/UnitTest1.cs
@@ -5,14 +5,12 @@ using RestSharp;
 
 namespace APIAutomation;
 
-public class Tests
+public class Tests : ApiTestBase
 {
     [Test]
     public async Task GetPostReturnsId1()
     {
-        var client = new RestClient("https://jsonplaceholder.typicode.com");
-        var request = new RestRequest("/posts/1", Method.Get);
-        var response = await client.ExecuteGetAsync<Post>(request);
+        var response = await GetAsync<Post>("/posts/1");
         Assert.Multiple(() =>
         {
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));

--- a/APIAutomation/UnitTest1.cs
+++ b/APIAutomation/UnitTest1.cs
@@ -1,5 +1,5 @@
 using System.Net;
-
+using APIAutomation.models;
 using NUnit.Framework;
 
 namespace APIAutomation;
@@ -15,10 +15,5 @@ public class Tests : ApiTestBase
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(response.Data?.Id, Is.EqualTo(1));
         });
-    }
-
-    private class Post
-    {
-        public int Id { get; set; }
     }
 }

--- a/APIAutomation/UnitTest1.cs
+++ b/APIAutomation/UnitTest1.cs
@@ -1,7 +1,6 @@
 using System.Net;
 
 using NUnit.Framework;
-using RestSharp;
 
 namespace APIAutomation;
 

--- a/APIAutomation/models/Post.cs
+++ b/APIAutomation/models/Post.cs
@@ -1,0 +1,9 @@
+namespace APIAutomation.models;
+
+public class Post
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    public string? Body { get; set; }
+    public int UserId { get; set; }
+}

--- a/UIAutomation/PlaywrightTestBase.cs
+++ b/UIAutomation/PlaywrightTestBase.cs
@@ -1,0 +1,43 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace UIAutomation;
+
+public abstract class PlaywrightTestBase
+{
+    protected IPlaywright PlaywrightInstance = default!;
+    protected IBrowser Browser = default!;
+    protected IBrowserContext Context = default!;
+    protected IPage Page = default!;
+
+    [OneTimeSetUp]
+    public async Task GlobalSetUp()
+    {
+        PlaywrightInstance = await Microsoft.Playwright.Playwright.CreateAsync();
+        Browser = await PlaywrightInstance.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = false,
+            Args = new[] { "--ignore-certificate-errors" }
+        });
+    }
+
+    [SetUp]
+    public async Task SetUpAsync()
+    {
+        Context = await Browser.NewContextAsync(new BrowserNewContextOptions { IgnoreHTTPSErrors = true });
+        Page = await Context.NewPageAsync();
+    }
+
+    [TearDown]
+    public async Task TearDownAsync()
+    {
+        await Context.CloseAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task GlobalTearDownAsync()
+    {
+        await Browser.CloseAsync();
+        PlaywrightInstance.Dispose();
+    }
+}

--- a/UIAutomation/UnitTest1.cs
+++ b/UIAutomation/UnitTest1.cs
@@ -4,20 +4,12 @@ using NUnit.Framework;
 
 namespace UIAutomation;
 
-public class Tests
+public class Tests : PlaywrightTestBase
 {
     [Test]
     public async Task VerifyTitleContainsPlaywright()
     {
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = false,
-            Args = ["--ignore-certificate-errors"]
-        });
-        var context = await browser.NewContextAsync(new BrowserNewContextOptions { IgnoreHTTPSErrors = true });
-        var page = await context.NewPageAsync();
-        await page.GotoAsync("https://playwright.dev");
-        StringAssert.Contains("Playwright", await page.TitleAsync());
+        await Page.GotoAsync("https://playwright.dev");
+        StringAssert.Contains("Playwright", await Page.TitleAsync());
     }
 }

--- a/UIAutomation/UnitTest1.cs
+++ b/UIAutomation/UnitTest1.cs
@@ -1,5 +1,3 @@
-using Microsoft.Playwright;
-
 using NUnit.Framework;
 
 namespace UIAutomation;


### PR DESCRIPTION
## Summary
- implement `ApiTestBase` for shared RestSharp client setup
- implement `PlaywrightTestBase` to manage Playwright lifecycle
- refactor existing tests to use the new base classes

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9cdd4da4832e93d97ee68dfc53a7